### PR TITLE
Fiexed streaming datatype mismatch.

### DIFF
--- a/sound_encoder.py
+++ b/sound_encoder.py
@@ -39,7 +39,7 @@ class Encoder:
 
   def encodeplay(self, somestring):
     soundlist = self.string2sound(somestring)
-    self.stream.write(soundlist.astype(np.dtype('int16')))
+    self.stream.write(soundlist.astype(np.dtype('int16')).tobytes())
 
   def getbit(self, freq):
 


### PR DESCRIPTION
I found a streaming issue in encoder that _encodeplay_ doesn't send correct datatype. The stream.write treats data as bytes not numpy.ndarray.
_encode2wav_ has been works fine.
Please accept this PR.

Thanks,
